### PR TITLE
Add: endpoint patch para edição de status da materia

### DIFF
--- a/app/Http/Controllers/MateriasController.php
+++ b/app/Http/Controllers/MateriasController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\ChangeStatusMateriaRequest;
 use App\Http\Requests\StoreMateriasRequest;
 use App\Http\Requests\UpdateMateriasRequest;
 use App\Models\Materias;
@@ -51,6 +52,32 @@ class MateriasController extends Controller
             return response()->json([
                 'success' => false,
                 'message' => 'Erro ao atualizar a matéria',
+                'error' => $e->getMessage(),
+            ], 500);
+        }
+    }
+
+    public function changeStatus(ChangeStatusMateriaRequest $request, Materias $materia){
+
+        try{
+            $validated = $request->validated();
+
+            $validated['ultimo_editor'] = auth()->user()->id;
+
+            $materia->update([
+                'status' => $validated['status'],
+                'ultimo_editor' => $validated['ultimo_editor'],
+            ]);
+
+            return response()->json([
+                'success' => true,
+                'message' => 'Status alterado com sucesso',
+                'data' => $materia->fresh(),
+            ]);
+        }catch (\Exception $e) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Erro ao alterar status',
                 'error' => $e->getMessage(),
             ], 500);
         }

--- a/app/Http/Requests/ChangeStatusMateriaRequest.php
+++ b/app/Http/Requests/ChangeStatusMateriaRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ChangeStatusMateriaRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return auth()->user() && auth()->user()->tipo === 'ADM';
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'status' => 'required|in:Ativo,Inativo'
+        ];
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -12,5 +12,6 @@ Route::middleware('auth:api')->get('/user', function (Request $request) {
 Route::middleware('auth:api')->group(function () {
     Route::apiResource('users', SystemUserController::class);
     Route::apiResource('materias', MateriasController::class);
+    Route::patch('materias/{materia}/status', [MateriasController::class, 'changeStatus']);
     Route::patch('users/{user}/status', [SystemUserController::class, 'changeStatus']);
 });


### PR DESCRIPTION
Criado endpoint PATCH para a edição de status matérias:

Body da requisição: 

```json
{
    "status": "Ativo"
}
```

Exemplo de response:

```json
{
    "success": true,
    "message": "Status alterado com sucesso",
    "data": {
        "id": 10,
        "nome": "Nova Matéria Atualizada",
        "descricao": "Descrição atualizada para a matéria com ID 10",
        "criador": 39,
        "status": "Ativo",
        "ultimo_editor": 11,
        "created_at": "2025-10-03T01:56:03.000000Z",
        "updated_at": "2025-10-03T02:57:16.000000Z"
    }
}
```

Rota autenticada, preciso está autenticado e ser um ADMIN para poder alterar o status da materia.
