### PR TITLE
Add: destroy function materias

### DIFF
--- a/app/Http/Controllers/MateriasController.php
+++ b/app/Http/Controllers/MateriasController.php
@@ -116,4 +116,30 @@ class MateriasController extends Controller
             ], 500);
         }
     }
+
+    public function destroy(Materias $materia):JsonResponse{
+        try{
+
+            if(! (auth()->user() && auth()->user()->tipo === "ADM")){
+                return response()->json([
+                    'success' => false,
+                    'message' => 'Acesso negado',
+                ],403);
+            }
+            
+
+            $materia->delete();
+
+            return response()->json([
+                'success' => true,
+                'message' => 'Materia excluir com sucesso',
+            ]);
+        }catch(\Exception $e){
+            return response()->json([
+                'success' => false,
+                'message' => 'Erro ao excluir a matéria'
+            ], 500);
+        }
+    }
+
 }


### PR DESCRIPTION
Criada função para deletar a matérias, apenas usário ADM pode fazer isso, qualquer outro tomará 403:

```php
public function destroy(Materias $materia):JsonResponse{
        try{

            if(! (auth()->user() && auth()->user()->tipo === "ADM")){
                return response()->json([
                    'success' => false,
                    'message' => 'Acesso negado',
                ],403);
            }
            

            $materia->delete();

            return response()->json([
                'success' => true,
                'message' => 'Materia excluir com sucesso',
            ]);
        }catch(\Exception $e){
            return response()->json([
                'success' => false,
                'message' => 'Erro ao excluir a matéria'
            ], 500);
        }
    }
```

Resolves #40 